### PR TITLE
access partitioning proof-of-concept

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -40,6 +40,7 @@
     "@backstage/plugin-azure-sites-backend": "workspace:^",
     "@backstage/plugin-badges-backend": "workspace:^",
     "@backstage/plugin-catalog-backend": "workspace:^",
+    "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-code-coverage-backend": "workspace:^",
     "@backstage/plugin-entity-feedback-backend": "workspace:^",

--- a/packages/backend/src/plugins/permission.ts
+++ b/packages/backend/src/plugins/permission.ts
@@ -93,12 +93,14 @@ class ExamplePermissionPolicy implements PermissionPolicy {
     const result = await Promise.all(
       entity?.relations
         ?.filter(r =>
-          [
-            RELATION_PARENT_OF,
-            RELATION_CHILD_OF,
-            RELATION_MEMBER_OF,
-            RELATION_HAS_MEMBER,
-          ].includes(r.type),
+          [RELATION_PARENT_OF, RELATION_HAS_MEMBER]
+            .concat(
+              entity?.metadata.annotations?.['tanzu.vmware.com/space'] ===
+                'false' || entity.kind === 'User'
+                ? [RELATION_CHILD_OF, RELATION_MEMBER_OF]
+                : [],
+            )
+            .includes(r.type),
         )
         .map(r => r.targetRef)
         .filter(r => r.startsWith('group:') || r.startsWith('user:'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -22899,6 +22899,7 @@ __metadata:
     "@backstage/plugin-azure-sites-backend": "workspace:^"
     "@backstage/plugin-badges-backend": "workspace:^"
     "@backstage/plugin-catalog-backend": "workspace:^"
+    "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-code-coverage-backend": "workspace:^"
     "@backstage/plugin-entity-feedback-backend": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've tested this by doing the following:
1. running `yarn start-backend` with the following `app-config.local.yaml`:
    ```yaml
    permission:
      enabled: true
    auth:
      environment: development
      providers:
        microsoft:
          development:
            tenantId: $(az account tenant list -o tsv --query '[].tenantId')
            clientId: $(az ad app create -o tsv --query appId --display-name my-backstage --web-redirect-uris http://localhost:7007/api/auth/microsoft/handler/frame)
            clientSecret: $(az ad app credential reset -o tsv --query password --append --id ${clientId})
    catalog:
      locations:
        - type: file
          target: ../../ownership.yaml
          rules:
            - allow: [User, Group, Component]
    ```
    where `ownership.yaml` looks like
    ```
    ---
    apiVersion: backstage.io/v1alpha1
    kind: Group
    metadata:
      name: org-a
    spec:
      type: org
      children: [team-a, team-b]
    ---
    apiVersion: backstage.io/v1alpha1
    kind: Group
    metadata:
      name: team-a
    spec:
      type: team
      children: []
    ---
    apiVersion: backstage.io/v1alpha1
    kind: Group
    metadata:
      name: team-b
    spec:
      type: team
      children: []
    ---
    apiVersion: backstage.io/v1alpha1
    kind: Component
    metadata:
      name: component-a
    spec:
      type: service
      lifecycle: experimental
      owner: team-b
    ---
    apiVersion: backstage.io/v1alpha1
    kind: User
    metadata:
      name: ${AZURE_USERID}
      annotations:
        'microsoft.com/email': ${AZURE_EMAIL}
    spec:
      memberOf: [team-a]
    ```
2. Opening `http://localhost:7007/api/auth/microsoft/start?scope=openid+offline_access&env=development` in a browser, following redirects + consenting until redirected back to `http://localhost:7007/api/auth/microsoft/handler/frame`.
3. Getting a backstage token by running
    ```bash
    JSON.parse(authResponse).response.backstageIdentity.token
    ```
    at the browser's Javascript console.
4. Back in  shell, setting the env var `$BACKSTAGE_TOKEN` to this value.
5. Making an authorization request for the `catalog.entity.read` permission by running:
    ```bash
    curl -s \
      -H "Authorization: Bearer $BACKSTAGE_TOKEN" \
      -H 'content-type:application/json' \
      localhost:7007/api/permission/authorize -d '
        {
          "items": [
            {
              "id": "id",
              "permission": {
                "type": "resource",
                "resourceType": "catalog-entity",
                "name": "catalog.entity.read",
                "attributes": {
                  "action": "create"
                }
              }
            }
          ]
        }
      ' | jq '.items[0]'
    ```

The result shows that the authorization policy has enumerated the connected component of the graph whose nodes are given by entities and whose edges are given by the `parentOf`,`childOf`,`memberOf` and `hasMember` relations specifically:

```json
{
  "id": "foo",
  "result": "CONDITIONAL",
  "pluginId": "catalog",
  "resourceType": "catalog-entity",
  "conditions": {
    "anyOf": [
      {
        "not": {
          "rule": "IS_ENTITY_KIND",
          "resourceType": "catalog-entity",
          "params": {
            "kinds": [
              "Component"
            ]
          }
        }
      },
      {
        "rule": "IS_ENTITY_OWNER",
        "resourceType": "catalog-entity",
        "params": {
          "claims": [
            "user:default/${AZURE_USERID}",
            "group:default/team-a",
            "group:default/org-a",
            "group:default/team-b"
          ]
        }
      }
    ]
  }
}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
